### PR TITLE
Changed NARGCHK to NARGINCHK (old syntax)

### DIFF
--- a/_libOomao/phaseStats.m
+++ b/_libOomao/phaseStats.m
@@ -327,7 +327,7 @@ classdef phaseStats
             %
             % See also atmosphere
             
-            error(nargchk(2,3,nargin))
+            narginchk(2,3)
             rho1 = varargin{1}(:);
             if nargin==2
                 atm  = varargin{2};


### PR DESCRIPTION
Just changed to suppress the warnings that matlab gives about NARGINCHK not being in future releases.